### PR TITLE
Fix: Reflect `System.usleep` interval restriction of Idris-dev

### DIFF
--- a/src/System/Posix/Test/Signal.idr
+++ b/src/System/Posix/Test/Signal.idr
@@ -17,6 +17,6 @@ test_install_handler : IO ()
 test_install_handler = do
   rc <- install_signal_handler SIGINT my_handler_wrapper
   putStrLn "Now press Ctrl-C to interrupt"
-  usleep 100000000
+  usleep 1000000
   putStrLn "Test completed. Did you see a message indicating signal 2 was handled?"
 


### PR DESCRIPTION
`usleep 100000000` fails to compile since [this commit](https://github.com/idris-lang/Idris-dev/commit/13449b52c409ad888077b93cf88a4ba8dbff5e7d).