### PR TITLE
Added createDirectory and getCurrentDirectory

### DIFF
--- a/posix.ipkg
+++ b/posix.ipkg
@@ -11,7 +11,9 @@ objs = dirent_accessors.c
      , stat_wrappers.c
      , time_wrappers.c
      , signal_wrappers.c
-     , syslog_wrappers.c     
+     , syslog_wrappers.c
+     , getcwd_wrapper.c
+     , create_dir_wrappers.c
 
 tests = System.Posix.Test.Syslog.test_syslog
       , System.Posix.Test.Signal.test_install_handler -- keep this test last

--- a/src/System/Posix/Directory.idr
+++ b/src/System/Posix/Directory.idr
@@ -2,6 +2,8 @@ module System.Posix.Directory
 
 %include C "dirent_accessors.c"
 %include C "stat_wrappers.c"
+%include C "getcwd_wrapper.c"
+%include C "create_dir_wrappers.c"
 
 opendir : String -> IO Ptr
 opendir s = foreign FFI_C "opendir" (String -> IO Ptr) s
@@ -31,8 +33,21 @@ getDirectoryContents s = do
               n <- dirent_d_name c
               f d (n :: xs)
 
+export
 doesFileExist : String -> IO Bool
 doesFileExist s = map (/= 0) (foreign FFI_C "idris_posix_is_file" (String -> IO Int) s)
 
+export
 doesDirectoryExist : String -> IO Bool
 doesDirectoryExist s = map (/= 0) (foreign FFI_C "idris_posix_is_directory" (String -> IO Int) s)
+
+||| Calls `getcwd` to get the current directory
+export
+getCurrentDirectory : IO String
+getCurrentDirectory = foreign FFI_C "idris_getcwd" (IO String)
+
+||| Create a new directory at this path
+||| NOTE that this currently does not perform error checking!
+export
+createDirectory : String -> IO ()
+createDirectory str = foreign FFI_C "idris_create_dir" (String -> IO Int) str *> pure ()

--- a/src/create_dir_wrappers.c
+++ b/src/create_dir_wrappers.c
@@ -1,0 +1,7 @@
+#include <sys/stat.h>
+
+int idris_create_dir(const char* filename) {
+    // For now we simply assign all the permissions
+    // More fine grained control may be subject of future work
+    return mkdir(filename, S_IRWXO | S_IRWXG | S_IRWXU);
+}

--- a/src/getcwd_wrapper.c
+++ b/src/getcwd_wrapper.c
@@ -1,0 +1,16 @@
+#include <unistd.h>
+
+
+// Used to avoid recomputing the buffer size for the `getcwd` call
+long int _idris_getcwd_pmax = 0;
+
+char *idris_getcwd() {
+    if (_idris_getcwd_pmax == 0) {
+        _idris_getcwd_pmax = pathconf("/", _PC_PATH_MAX);
+    }
+    // Passing NULL here is part of the extended POSIX interface.
+    // It means `getcwd` allocates the buffer itself.
+    // Should it transpire that too few platforms support this
+    // we may have to allocate the buffer ourselves.
+    return getcwd(NULL, _idris_getcwd_pmax);
+}


### PR DESCRIPTION
Added a basic version of `createDirectory` (currently assigns all permissions) and a version of `getCurrentDirectory` (uses `getcwd` with the extended POSIX API of passing `NULL`)