### PR TITLE
Fix build for Ubuntu 18.10

### DIFF
--- a/src/stat_wrappers.c
+++ b/src/stat_wrappers.c
@@ -3,13 +3,13 @@
 inline int idris_posix_stat_file_type(char *filename) {
   struct stat buffer;
   stat(filename, &buffer);
-  return buffer.st_mode & S_IFMT;
+  return buffer.st_mode;
 }
 
 inline int idris_posix_is_directory(char *filename) {
-  return idris_posix_stat_file_type(filename) == S_IFDIR;
+  return S_ISDIR(idris_posix_stat_file_type(filename));
 }
 
 inline int idris_posix_is_file(char *filename) {
-  return idris_posix_stat_file_type(filename) == S_IFREG;
+  return S_ISREG(idris_posix_stat_file_type(filename));
 }


### PR DESCRIPTION
idris-posix fails to build on my machine. According to [this](https://stackoverflow.com/questions/28547271/s-ifmt-and-s-ifreg-undefined-with-std-c11-or-std-gnu11/28547415) QA, `S_ISDIR` and `S_ISREG` is more portable.

detailed info
<details>


# Error Message

``` console
Entering directory `./src'
Type checking ./Main.idr
In file included from /tmp/idris68312-0.c:3:
/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/libs/posix/stat_wrappers.c: In function ‘idris_posix_stat_file_type’:
/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/libs/posix/stat_wrappers.c:6:27: error: ‘S_IFMT’ undeclared (first use in this function); did
you mean ‘S_IXOTH’?
   return buffer.st_mode & S_IFMT;
                           ^~~~~~
                           S_IXOTH
/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/libs/posix/stat_wrappers.c:6:27: note: each undeclared identifier is reported only once for each function it appears in
FAILURE: "cc" ["-O1","-foptimize-sibling-calls","-fwrapv","-fno-strict-overflow","-std=c99","-pipe","-fdata-sections","-ffunction-sections","-D_POSIX_C_SOURCE=200809L","-DHAS_PTHREAD","-DIDRIS_ENABLE_STATS","-I.","-Wl,-gc-sections","/tmp/idris68312-0.c","-L/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/rts","-lidris_rts","-lgmp","-lpthread","-I/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/rts","-lm","-I.","-I/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/libs/posix","-I/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/libs/prelude","-I/home/shun/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.3.0/libs/base","-I.","-I/home/kim/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.2.0/libs/prelude","-I/home/kim/compile/Idris-dev/.stack-work/install/x86_64-linux/lts-11.3/8.2.2/share/x86_64-linux-ghc-8.2.2/idris-1.2.0/libs/base","-o","/home/shun/Idris/idris-posix-sandbox/main"]
Leaving directory `./src'
```

# Versions

``` console
$ gcc --version
gcc (Ubuntu 8.2.0-7ubuntu1) 8.2.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ idris --version
1.3.0-git:61cf812e
$ uname -a
Linux fractal 4.18.0-11-generic #12-Ubuntu SMP Tue Oct 23 19:22:37 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```

</details>